### PR TITLE
Saving output coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # HMI / Hinode Co-alignment
-A code for determining the helio-projective (HP) coordinates of Hinode magnetograms using co-temporal HMI magnetograms.
+A code for determining the helio-projective cartesian (HPC) coordinates of Hinode magnetograms using co-temporal HMI magnetograms.
 
 ![Alt text](alignment.png)
 
 
 ---
 ## General Overview
-We upscale HMI data to Hinode's resolution by interpolating HMI onto an irregular grid of HP coordinates, and cross-correlating the interpolated HMI magnetograms with the Hinode observations. 
+We upscale HMI data to Hinode's resolution by interpolating HMI onto an irregular grid of HPC coordinates, and cross-correlating the interpolated HMI magnetograms with the Hinode observations. 
 
 Although other codes exist for this problem, we were interested in writing one with a few differences in mind:
 
@@ -23,8 +23,8 @@ Although other codes exist for this problem, we were interested in writing one w
      4. $\delta_x$: a multiplier offset to correct for the spacing of x-coordinates   
      5. $\delta_y$: a multiplier offset to correct for the spacing of y-coordinates (here, we're assuming the spacing in x and y are constant, but may be the wrong spacing from the Hinode header)
 
-#### An Example Run of the Code: 
+#### An Example Run of the Code, which will plot the final alignment and save the final coordinates: 
 
-    python interpolate.py --path_to_slits '/Users/jamescrowley/Documents/Fall_2023/research/LWS/raster1_slits/' --name_hinode_B '/Users/jamescrowley/Documents/Fall_2023/research/LWS/inv_res_mod_raster1.fits' --path_to_sunpy '/Users/jamescrowley/sunpy/'
+    python interpolate.py --plot True --path_to_slits '/Users/jamescrowley/Documents/Fall_2023/research/LWS/raster1_slits/' --name_hinode_B '/Users/jamescrowley/Documents/Fall_2023/research/LWS/inv_res_mod_raster1.fits' --path_to_sunpy '/Users/jamescrowley/sunpy/' --output_format '["HPCx", "HPCy"]'
 
 A work-in-progress. Contact: james.crowley (at) colorado.edu

--- a/interpolate.py
+++ b/interpolate.py
@@ -24,6 +24,12 @@ def main():
                         type=str,
                         required=True,
                         help='path to sunpy. On my computer it is /Users/jamescrowley/sunpy/')
+    parser.add_argument('--output_format',
+                        dest='output_format',
+                        type=list,
+                        required=True,
+                        help='output format to save the coords. if only vizualizing, use []. otherwise, accepted'
+                             'arguments are "HPCx", "HPCy", "hinodeB"')
 
     arg = parser.parse_args()
 
@@ -31,6 +37,7 @@ def main():
     path_to_slits = arg.path_to_slits
     name_hinode_B = arg.name_hinode_B
     path_to_sunpy = arg.path_to_sunpy
+    output_format = arg.output_format
 
     hinode_model = du.fits.open(name_hinode_B)[0].data
     hinode_B = hinode_model[4, 10] * du.np.cos(hinode_model[6, 10] * du.np.pi / 180)
@@ -39,7 +46,9 @@ def main():
     du.run(path_to_slits,
            hinode_B,
            bounds=[(25, 35), (15, 25), (0.9, 1.1), (0.9, 1.1), (-2, 2)],
-           path_to_sunpy = path_to_sunpy)
+           path_to_sunpy=path_to_sunpy,
+           output_format=output_format,
+           plot=plot)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Added flag for whether or not to plot the final alignment
2. Added options to save the output coordinates. Right now, limited functionality. If you don't want to save anything, use --output_format [], otherwise, can pass in ["HPCx", "HPCy"] for just coordinates or ["HPCx", "HPCy", "hinodeB"] for coordinates and hinode B
3. Updated readme